### PR TITLE
feat: allow vendors to update master pricing for each currency

### DIFF
--- a/app/models/spree/vendor_ability.rb
+++ b/app/models/spree/vendor_ability.rb
@@ -69,7 +69,7 @@ class Spree::VendorAbility
   end
 
   def apply_price_permissions
-    can [:admin, :manage], Spree::Price, variant: { vendor_id: @vendor_ids }
+    can :manage, Spree::Price
   end
 
   def apply_product_option_type_permissions

--- a/app/models/spree/vendor_ability.rb
+++ b/app/models/spree/vendor_ability.rb
@@ -69,7 +69,7 @@ class Spree::VendorAbility
   end
 
   def apply_price_permissions
-    can :modify, Spree::Price, variant: { vendor_id: @vendor_ids }
+    can [:admin, :manage], Spree::Price, variant: { vendor_id: @vendor_ids }
   end
 
   def apply_product_option_type_permissions


### PR DESCRIPTION
Change the permissions to match `Spree::Stock`.

Note: using `variant: { vendor_id: @vendor_ids }` causes an authorization error even if variant belongs to vendor. Setting permissions to match `Spree::Stock` ([here](https://github.com/spree-contrib/spree_multi_vendor/blob/077f120cf37f50d65f062e8756451fa2c44b312b/app/models/spree/vendor_ability.rb#L113)) solves the problem